### PR TITLE
Fixed multiple table joins

### DIFF
--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -410,11 +410,11 @@ abstract class BaseAdapter
             return $sql;
         }
 
-        foreach ($statements['joins'] as $type => $joinArr) {
+        foreach ($statements['joins'] as $joinArr) {
             $table = $this->wrapSanitizer($joinArr['table']);
             $joinBuilder = $joinArr['joinBuilder'];
 
-            $sqlArr = array($sql, strtoupper($type), 'JOIN', $table, 'ON', $joinBuilder->getQuery('criteriaOnly', false)->getSql());
+            $sqlArr = array($sql, strtoupper($joinArr['type']), 'JOIN', $table, 'ON', $joinBuilder->getQuery('criteriaOnly', false)->getSql());
             $sql = $this->concatenateQuery($sqlArr);
         }
 

--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -484,12 +484,12 @@ class QueryBuilderHandler
         // Build a new JoinBuilder class, keep it by reference so any changes made
         // in the closure should reflect here
         $joinBuilder = $this->container->build('\\Pixie\\QueryBuilder\\JoinBuilder', array($this->connection));
-        $joinBuilder = & $joinBuilder;
+
         // Call the closure with our new joinBuilder object
         $key($joinBuilder);
         $table = $this->addTablePrefix($table, false);
         // Get the criteria only query from the joinBuilder object
-        $this->statements['joins'][$type] = compact('table', 'joinBuilder');
+        $this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
 
         return $this;
     }


### PR DESCRIPTION
I noticed that trying to do more than one join of the same type doesn't work due to subsequent joins of the same type overwriting the prior join. This is a small fix to allow for any number of joins.

I also removed this line 487 of QueryBuilderHandler.php while I was in there as it doesn't do anything

```
$joinBuilder = & $joinBuilder;
```
