### PR TITLE
Update QueryBuilderHandler.php

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -92,7 +92,7 @@ class QueryBuilderHandler
      */
     public function query($sql, $bindings = array())
     {
-        $this->statement($sql, $bindings);
+        $this->pdoStatement = $this->statement($sql, $bindings);
         
         return $this;
     }


### PR DESCRIPTION
Add a statement method which returns the pdoStatement object. (see the laravel equivalent: https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Connection.php#L329 which can be used directly from the query builder)

Use this to return the pdoStatment for updates and deletes.

The information held in the statement such as rowCount() and errorInfo() after these operations is vital to know whether your update/delete has affected any rows. Seeing as nothing is being returned in these functions any, it should not affect any existing interfaces.
