### PR TITLE
added set fetch mode method

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -42,6 +42,13 @@ class QueryBuilderHandler
     protected $adapterInstance;
 
     /**
+     * The PDO fetch mode to use
+     *
+     * @var int
+     */
+    protected $fetchMode = \PDO::FETCH_OBJ;
+
+    /**
      * @param null|\Pixie\Connection $connection
      *
      * @throws \Pixie\Exception
@@ -68,6 +75,16 @@ class QueryBuilderHandler
         $this->adapterInstance = $this->container->build('\\Pixie\\QueryBuilder\\Adapters\\' . ucfirst($this->adapter), array($this->connection));
 
         $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+    }
+
+    /**
+     * Set the fetch mode
+     *
+     * @param $mode
+     */
+    public function setFetchMode($mode)
+    {
+        $this->fetchMode = $mode;
     }
 
     /**
@@ -119,7 +136,7 @@ class QueryBuilderHandler
     {
         $this->fireEvents('before-select');
         $this->preparePdoStatement();
-        $result = $this->pdoStatement->fetchAll(\PDO::FETCH_CLASS);
+        $result = $this->pdoStatement->fetchAll($this->fetchMode);
         $this->pdoStatement = null;
         $this->fireEvents('after-select', $result);
         return $result;


### PR DESCRIPTION
Something as simple as this might work for #15 but I don't know how you would like it to tie in with the rest of the library. This could be something that is set on the connection object too and when `getQueryBuilder` it passes in the default. 

Other option could be not to specify at all at this level, and use the adapter options from the initial constructor. It can't use them though as the query builder overrides it explicitly in `fetchAll(\PDO::FETCH_CLASS)`

Not sure - this is probably not a PR to merge, but at least its something to think about
