### PR TITLE
limit support for update and delete queries

### DIFF
--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -231,12 +231,16 @@ abstract class BaseAdapter
 
         // Wheres
         list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
+        
+        // Limit
+        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
 
         $sqlArray = array(
             'UPDATE',
             $table,
             'SET ' . $updateStatement,
             $whereCriteria,
+            $limit
         );
 
         $sql = $this->concatenateQuery($sqlArray, ' ', false);
@@ -263,8 +267,11 @@ abstract class BaseAdapter
 
         // Wheres
         list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
+        
+        // Limit
+        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
 
-        $sqlArray = array('DELETE from', $table, $whereCriteria);
+        $sqlArray = array('DELETE from', $table, $whereCriteria, $limit);
         $sql = $this->concatenateQuery($sqlArray, ' ', false);
         $bindings = $whereBindings;
 


### PR DESCRIPTION
I think it's useful. For example, resources withdrawing (or its properties updating) at MMORPG where each resource is a single row in database table.
