### PR TITLE
Fix sql error when COUNT and ORDER BY are used

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -218,6 +218,7 @@ class QueryBuilderHandler
         // Get the current statements
         $originalStatements = $this->statements;
 
+        unset($this->statements['orderBys']);
         unset($this->statements['limit']);
         unset($this->statements['offset']);
 


### PR DESCRIPTION
"SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'date_entered' in order clause is ambiguous"