### PR TITLE
Bind proper value datatype

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -139,7 +139,14 @@ class QueryBuilderHandler
     {
         $start = microtime(true);
         $pdoStatement = $this->pdo->prepare($sql);
-        $pdoStatement->execute($bindings);
+        foreach ($bindings as $key => $value) {
+            $pdoStatement->bindValue(
+                is_int($key) ? $key + 1 : $key,
+                $value,
+                is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+            );
+        }
+        $pdoStatement->execute();
         return array($pdoStatement, microtime(true) - $start);
     }
 

--- a/tests/Pixie/QueryBuilderTest.php
+++ b/tests/Pixie/QueryBuilderTest.php
@@ -1,5 +1,6 @@
 <?php namespace Pixie;
 
+use PDO;
 use Mockery as m;
 use Pixie\QueryBuilder\QueryBuilderHandler;
 
@@ -22,7 +23,13 @@ class QueryBuilder extends TestCase
         $query = 'select * from cb_my_table where id = ? and name = ?';
         $bindings = array(5, 'usman');
         $queryArr = $this->builder->query($query, $bindings)->get();
-        $this->assertEquals($queryArr, array($query, $bindings));
+        $this->assertEquals(
+            array(
+                $query,
+                array(array(5, PDO::PARAM_INT), array('usman', PDO::PARAM_STR)),
+            ),
+            $queryArr
+        );
     }
 
     public function testInsertQueryReturnsIdForInsert()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,12 +20,24 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 
         $mockPdoStatement = & $this->mockPdoStatement;
 
+        $mockPdoStatement->bindings = array();
+
+        $this->mockPdoStatement
+            ->expects($this->any())
+            ->method('bindValue')
+            ->will($this->returnCallback(function ($parameter, $value, $dataType) use ($mockPdoStatement) {
+                $mockPdoStatement->bindings[] = array($value, $dataType);
+            }));
+
         $this->mockPdoStatement
             ->expects($this->any())
             ->method('execute')
-            ->will($this->returnCallback(function($bindings) use ($mockPdoStatement){
-                $mockPdoStatement->bindings = $bindings;
+            ->will($this->returnCallback(function($bindings = null) use ($mockPdoStatement) {
+                if ($bindings) {
+                    $mockPdoStatement->bindings = $bindings;
+                }
             }));
+
 
         $this->mockPdoStatement
             ->expects($this->any())


### PR DESCRIPTION
Some of DBMS requires strict datatypes specification for binded
parameters. For example, [Sphinx] (http://sphinxsearch.com).