### PR TITLE
UPDATE/INSERT/DELETE now escape table names as well

### DIFF
--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -151,7 +151,7 @@ abstract class BaseAdapter
 
         $sqlArray = array(
             $type . ' INTO',
-            $table,
+            $this->wrapSanitizer($table),
             '(' . $this->arrayStr($keys, ',') . ')',
             'VALUES',
             '(' . $this->arrayStr($values, ',', false) . ')',

--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -268,7 +268,7 @@ abstract class BaseAdapter
 
         $sqlArray = array(
             'UPDATE',
-            $table,
+            $this->wrapSanitizer($table),
             'SET ' . $updateStatement,
             $whereCriteria,
             $limit
@@ -302,7 +302,7 @@ abstract class BaseAdapter
         // Limit
         $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
 
-        $sqlArray = array('DELETE from', $table, $whereCriteria, $limit);
+        $sqlArray = array('DELETE FROM', $this->wrapSanitizer($table), $whereCriteria);
         $sql = $this->concatenateQuery($sqlArray, ' ', false);
         $bindings = $whereBindings;
 
@@ -402,7 +402,7 @@ abstract class BaseAdapter
                         }
 
                         $valuePlaceholder = trim($valuePlaceholder, ', ');
-                        $criteria .= ' (' . $valuePlaceholder . ') ';
+                   d     $criteria .= ' (' . $valuePlaceholder . ') ';
                         break;
                 }
             } else {

--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -402,7 +402,7 @@ abstract class BaseAdapter
                         }
 
                         $valuePlaceholder = trim($valuePlaceholder, ', ');
-                   d     $criteria .= ' (' . $valuePlaceholder . ') ';
+                        $criteria .= ' (' . $valuePlaceholder . ') ';
                         break;
                 }
             } else {

--- a/tests/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pixie/QueryBuilderBehaviorTest.php
@@ -196,7 +196,7 @@ class QueryBuilderTest extends TestCase
         $data = array('key' => 'Name',
             'value' => 'Sana',);
 
-        $this->assertEquals("INSERT IGNORE INTO cb_my_table (`key`,`value`) VALUES ('Name','Sana')"
+        $this->assertEquals("INSERT IGNORE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
             , $builder->getQuery('insertignore', $data)->getRawSql());
     }
 
@@ -206,7 +206,7 @@ class QueryBuilderTest extends TestCase
         $data = array('key' => 'Name',
             'value' => 'Sana',);
 
-        $this->assertEquals("REPLACE INTO cb_my_table (`key`,`value`) VALUES ('Name','Sana')"
+        $this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
             , $builder->getQuery('replace', $data)->getRawSql());
     }
 
@@ -222,7 +222,7 @@ class QueryBuilderTest extends TestCase
             'counter' => 2
         );
         $builder->from('my_table')->onDuplicateKeyUpdate($dataUpdate);
-        $this->assertEquals("INSERT INTO cb_my_table (`name`,`counter`) VALUES ('Sana',1) ON DUPLICATE KEY UPDATE `name`='Sana',`counter`=2"
+        $this->assertEquals("INSERT INTO `cb_my_table` (`name`,`counter`) VALUES ('Sana',1) ON DUPLICATE KEY UPDATE `name`='Sana',`counter`=2"
             , $builder->getQuery('insert', $data)->getRawSql());
     }
 


### PR DESCRIPTION
Fixes issue where UPDATE and DELETE queries didn't escape table names. This could lead to issues when table names included special characters like a backslash. This was fixed by passing the table name into the already existing wrapSanitizer() method used by select queries.
This fixes #60 