### PR TITLE
Without sanitizing whereNull, whereNotNull, orWhereNull, orWhereNotNull is vulnerable to an injection.

### DIFF
--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -441,7 +441,7 @@ abstract class BaseAdapter
      *
      * @return string
      */
-    protected function wrapSanitizer($value)
+    public function wrapSanitizer($value)
     {
         // Its a raw query, just cast as string, object has __toString()
         if ($value instanceof Raw) {

--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -750,7 +750,8 @@ class QueryBuilderHandler
 
     protected function _whereNull($key, $prefix = '', $operator = '')
     {
-        return $this->{$operator . 'Where'}($this->raw("{$this->addTablePrefix($key)} IS {$prefix} NULL"));
+        $key = $this->adapterInstance->wrapSanitizer($this->addTablePrefix($key));
+        return $this->{$operator . 'Where'}($this->raw("{$key} IS {$prefix} NULL"));
     }
 
     /**

--- a/tests/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pixie/QueryBuilderBehaviorTest.php
@@ -264,4 +264,18 @@ class QueryBuilderTest extends TestCase
         );
     }
 
+    public function testSelectQueryWithNull()
+    {
+        $query = $this->builder->from('my_table')
+                ->whereNull('key1')
+                ->orWhereNull('key2')
+                ->whereNotNull('key3')
+                ->orWhereNotNull('key4');
+
+        $this->assertEquals(
+            "SELECT * FROM `cb_my_table` WHERE `key1` IS  NULL OR `key2` IS  NULL AND `key3` IS NOT NULL OR `key4` IS NOT NULL",
+            $query->getQuery()->getRawSql()
+        );
+    }
+
 }


### PR DESCRIPTION
For instance,
whereNotNull('1') will expand into WHERE 1 NOT NULL
whereNull('NULL') will expand into WHERE NULL IS  NULL

which effectively neutralizes a condition.

Additional reason to make sanitizer public - it is handy while working
with raw queries outside the library.