### PR TITLE
Update Mysql connection adapter to use unix_socket

### DIFF
--- a/src/Pixie/ConnectionAdapters/Mysql.php
+++ b/src/Pixie/ConnectionAdapters/Mysql.php
@@ -9,8 +9,12 @@ class Mysql extends BaseAdapter
      */
     protected function doConnect($config)
     {
-        $connectionString = "mysql:host={$config['host']};dbname={$config['database']}";
-
+        $connectionString = "mysql:dbname={$config['database']}";
+        
+        if (isset($config['host'])) {
+            $connectionString .= ";host={$config['host']}";
+        }
+        
         if (isset($config['port'])) {
             $connectionString .= ";port={$config['port']}";
         }


### PR DESCRIPTION
As seen in the doc (http://php.net/manual/en/ref.pdo-mysql.connection.php), you shouldn't use unix_socket with host or port. You could either let the programmer sets or not the host (like I did), or check if unix_socket is used and drop host and port.

Thanks,
Marc