### PR TITLE
Correction for issue 83

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -255,9 +255,9 @@ class QueryBuilderHandler
             unset($this->statements['selects']);
         }
 
-        if ($row[0]['field']) {
+        if (is_array($row[0])) {
             return (int) $row[0]['field'];
-        } else if ($row[0]->field) {
+        } else if (is_object($row[0])) {
             return (int) $row[0]->field;
         }
 


### PR DESCRIPTION
The commit 97bd69e added lines

```php
if ($row[0]['field']) {
    return (int) $row[0]['field'];
} else if ($row[0]->field) {
    return (int) $row[0]->field;
}
```

to correct the count when using different fetch modes. First, if $row[0] is stdClass, the [] operator cannot be used. Second, those conditions don't work when count is 0, because 0 in PHP is false. You should be checking is_array or is_object to know how to return the count.