### PR TITLE
Fix issue #86 by removing array type hinting on *whereIn method

### DIFF
--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -405,6 +405,8 @@ abstract class BaseAdapter
                         $criteria .= ' (' . $valuePlaceholder . ') ';
                         break;
                 }
+            } elseif ($value instanceof Raw) {
+                $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value";
             } else {
                 // Usual where like criteria
 

--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -655,7 +655,7 @@ class QueryBuilderHandler
      *
      * @return $this
      */
-    public function whereIn($key, array $values)
+    public function whereIn($key, $values)
     {
         return $this->_where($key, 'IN', $values, 'AND');
     }
@@ -677,7 +677,7 @@ class QueryBuilderHandler
      *
      * @return $this
      */
-    public function orWhereIn($key, array $values)
+    public function orWhereIn($key, $values)
     {
         return $this->_where($key, 'IN', $values, 'OR');
     }

--- a/tests/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pixie/QueryBuilderBehaviorTest.php
@@ -278,4 +278,16 @@ class QueryBuilderTest extends TestCase
         );
     }
 
+    public function testIsPossibleToUseSubqueryInWhereClause()
+    {
+        $sub = clone $this->builder;
+        $query = $this->builder->from('my_table')->whereIn('foo', $this->builder->subQuery(
+            $sub->from('some_table')->select('foo')->where('id', 1)
+        ));
+        $this->assertEquals(
+            "SELECT * FROM `cb_my_table` WHERE `foo` IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
+            $query->getQuery()->getRawSql()
+        );
+    }
+
 }


### PR DESCRIPTION
Also, it fixes ability to use subquery in WHERE statement. However, I
don't know how to test it correctly (was PDO-binding issue).