### PR TITLE
Allow multiple joins on same table due to if else statements.

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -798,7 +798,7 @@ class QueryBuilderHandler
         $key($joinBuilder);
         $table = $this->addTablePrefix($table, false);
         // Get the criteria only query from the joinBuilder object
-        $this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
+        $this->statements['joins'][$table] = compact('type', 'table', 'joinBuilder');
 
         return $this;
     }


### PR DESCRIPTION
I got two if statements that require the same join table to function. Both can be used without the other. So in both if statements I added a join, to make sure the table is available. This won't result into an error until it's being executed.

My quick fix is making the table the key of the join in the QueryBuilderHandler. I aware that an option would be to add the join when either of the if statements are triggered but that requires an extra if statement. I think it adds extra complexity and would like that the solution lays within the query builder.