### PR TITLE
[TASK] Added support for nested query-builder

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -141,8 +141,14 @@ class QueryBuilderHandler
     public function statement($sql, $bindings = array())
     {
         $start = microtime(true);
+
         $pdoStatement = $this->pdo->prepare($sql);
         foreach ($bindings as $key => $value) {
+
+            if($value instanceof self) {
+                $value = $value->getQuery()->getRawSql();
+            }
+
             $pdoStatement->bindValue(
                 is_int($key) ? $key + 1 : $key,
                 $value,

--- a/src/Pixie/QueryBuilder/QueryObject.php
+++ b/src/Pixie/QueryBuilder/QueryObject.php
@@ -70,6 +70,13 @@ class QueryObject
 
         # build a regular expression for each parameter
         foreach ($params as $key => $value) {
+
+            if($value instanceof QueryBuilderHandler) {
+                $keys[] = '/[?]/';
+                $values[$key] = '(' . $value->getQuery()->getRawSql() . ')';
+                continue;
+            }
+
             if (is_string($key)) {
                 $keys[] = '/:' . $key . '/';
             } else {


### PR DESCRIPTION
This feature will add support for nested queries.

Please not this example is taken from a live site, but it should provide an idea of what the changes are about.

**Example (psuedo code)**:

```php
$userDataQuery = $this->newQuery('user_data')
            ->getQuery()
            ->select('user_id')
            ->where('user_id', '=', \QB::raw('user.id'))
            ->where('value', 'LIKE', '%'. str_replace('%', '%%', $query) .'%')
            ->limit(1);

$otherQuery->where('username', 'LIKE', '%'.str_replace('%', '%%', $query).'%')
            ->orWhere('id', '=', $userDataQuery);
```

**Output:**

```sql
SELECT * FROM `user` WHERE `username` LIKE '%value%' OR `id` = (SELECT `user_id` FROM `user_data` WHERE `user_id` = user.id AND `value` LIKE '%value%' LIMIT 1)
```