### PR TITLE
Added support for * event matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,8 @@ Pixie comes with powerful query events to supercharge your application. These ev
 
 #### Available Events
 
+ - after-*
+ - before-*
  - before-select
  - after-select
  - before-insert

--- a/src/Pixie/EventHandler.php
+++ b/src/Pixie/EventHandler.php
@@ -34,6 +34,19 @@ class EventHandler
         if ($table instanceof Raw) {
             return null;
         }
+
+        // Find event with *
+        if(isset($this->events[$table])) {
+            foreach($this->events[$table] as $name => $e) {
+                if (stripos($name, '*') > - 1) {
+                    $name = substr($name, 0, strpos($name, '*'));
+                    if (stripos($event, $name) > - 1) {
+                        return $e;
+                    }
+                }
+            }
+        }
+
         return isset($this->events[$table][$event]) ? $this->events[$table][$event] : null;
     }
 


### PR DESCRIPTION
Sorry about the weird branch name, really got outta hand when i wrote it in the command-line :)

Small change that allows for wildcard in event-names.

Sometimes you might want to match every event - for debugging etc - without having to registering every single event (insert, update, delete etc etc).

Using the `*` wildcard you can match on every event like this:

`after-*` (all after events)
`before-*` (all before events)