### PR TITLE
Send data to eventhandler to mutate

### DIFF
--- a/src/Pixie/EventHandler.php
+++ b/src/Pixie/EventHandler.php
@@ -67,7 +67,7 @@ class EventHandler
      * @param                     $event
      * @return mixed
      */
-    public function fireEvents($queryBuilder, $event)
+    public function fireEvents($queryBuilder, $event, &$args = array())
     {
         $statements = $queryBuilder->getStatements();
         $tables = isset($statements['tables']) ? $statements['tables'] : array();
@@ -81,17 +81,14 @@ class EventHandler
             // Fire before events for :any table
             if ($action = $this->getEvent($event, $table)) {
                 // Make an event id, with event type and table
-                $eventId = $event . $table;
-
-                // Fire event
-                $handlerParams = func_get_args();
-                unset($handlerParams[1]); // we do not need $event
-                // Add to fired list
-                $this->firedEvents[] = $eventId;
-                $result = call_user_func_array($action, $handlerParams);
-                if (!is_null($result)) {
-                    return $result;
-                };
+              $eventId = $event . $table;       
+							$params = array($queryBuilder, $tables[$counter + 1], &$args);
+							// Add to fired list
+							$this->firedEvents[] = $eventId;
+							$result = call_user_func_array($action, $params);
+              if (!is_null($result)) {
+                  return $result;
+              };
             }
         }
     }


### PR DESCRIPTION
Make it possible to send the query or extra data to the thrown event so
it can be mutated. For example by adding a select column in all cases.