### PR TITLE
Fixed notices in QueryBuilderHandler

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -258,10 +258,12 @@ class QueryBuilderHandler
             unset($this->statements['selects']);
         }
 
-        if (is_array($row[0])) {
-            return (int) $row[0]['field'];
-        } elseif (is_object($row[0])) {
-            return (int) $row[0]->field;
+        if(isset($row[0])) {
+            if (is_array($row[0])) {
+                return (int)$row[0]['field'];
+            } elseif (is_object($row[0])) {
+                return (int)$row[0]->field;
+            }
         }
 
         return 0;


### PR DESCRIPTION
Fixed notices in `QueryBuilderHandler` class when `$row[0]` is not set.