### PR TITLE
Feature: no table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Library on [Packagist](https://packagist.org/packages/usmanhalalit/pixie).
     - [Get All](#get-all)
     - [Get First Row](#get-first-row)
     - [Get Rows Count](#get-rows-count)
+    - [Selects With Sub-Queries](#select-with-sub-queries)
  - [**Where**](#where)
     - [Where In](#where-in)
     - [Where Between](#where-between)
@@ -256,6 +257,21 @@ Returns the first row, or null if there is no record. Using this method you can 
 ```PHP
 $query = QB::table('my_table')->where('name', '=', 'Sana');
 $query->count();
+```
+
+#### Select With Sub-Queries
+
+```PHP
+$subQuery1 = $this->builder->table('mail')->select($this->builder->raw('COUNT(*)'));
+$subQuery2 = $this->builder->table('event_message')->select($this->builder->raw('COUNT(*)'));
+
+$count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'), $this->builder->subQuery($subQuery2, 'row2'))->first();
+```
+
+Will produce the following query:
+
+```sql
+SELECT (SELECT COUNT(*) FROM `cb_mail`) as row1, (SELECT COUNT(*) FROM `cb_event_message`) as row2 LIMIT 1
 ```
 
 ### Where

--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -32,14 +32,18 @@ abstract class BaseAdapter
      */
     public function select($statements)
     {
-        if (!array_key_exists('tables', $statements)) {
-            throw new Exception('No table specified.', 3);
-        } elseif (!array_key_exists('selects', $statements)) {
+        if (!array_key_exists('selects', $statements)) {
             $statements['selects'][] = '*';
         }
 
         // From
-        $tables = $this->arrayStr($statements['tables'], ', ');
+        $fromEnabled = false;
+        $tables = '';
+
+        if(isset($statements['tables'])) {
+            $tables = $this->arrayStr($statements['tables'], ', ');
+            $fromEnabled = true;
+        }
         // Select
         $selects = $this->arrayStr($statements['selects'], ', ');
 
@@ -77,7 +81,7 @@ abstract class BaseAdapter
         $sqlArray = array(
             'SELECT' . (isset($statements['distinct']) ? ' DISTINCT' : ''),
             $selects,
-            'FROM',
+            (($fromEnabled) ? 'FROM' : ''),
             $tables,
             $joinString,
             $whereCriteria,
@@ -129,10 +133,6 @@ abstract class BaseAdapter
      */
     private function doInsert($statements, array $data, $type)
     {
-        if (!isset($statements['tables'])) {
-            throw new Exception('No table specified', 3);
-        }
-
         $table = end($statements['tables']);
 
         $bindings = $keys = $values = array();
@@ -247,9 +247,7 @@ abstract class BaseAdapter
      */
     public function update($statements, array $data)
     {
-        if (!isset($statements['tables'])) {
-            throw new Exception('No table specified', 3);
-        } elseif (count($data) < 1) {
+        if (count($data) < 1) {
             throw new Exception('No data given.', 4);
         }
 
@@ -288,10 +286,6 @@ abstract class BaseAdapter
      */
     public function delete($statements)
     {
-        if (!isset($statements['tables'])) {
-            throw new Exception('No table specified', 3);
-        }
-
         $table = end($statements['tables']);
 
         // Wheres

--- a/tests/Pixie/NoTableSubQueryTest.php
+++ b/tests/Pixie/NoTableSubQueryTest.php
@@ -1,0 +1,33 @@
+<?php namespace Pixie;
+
+use PDO;
+use Mockery as m;
+use Pixie\QueryBuilder\QueryBuilderHandler;
+
+class NoTableSubQueryTest extends TestCase
+{
+    /**
+     * @var QueryBuilderHandler
+     */
+    protected $builder;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->builder = new QueryBuilderHandler($this->mockConnection);
+    }
+
+    public function testRawQuery()
+    {
+
+        $subQuery1 = $this->builder->table('mail')->select($this->builder->raw('COUNT(*)'));
+        $subQuery2 = $this->builder->table('event_message')->select($this->builder->raw('COUNT(*)'));
+
+        $count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'), $this->builder->subQuery($subQuery2, 'row2'))->first();
+
+        $this->assertEquals('SELECT (SELECT COUNT(*) FROM `cb_mail`) as row1, (SELECT COUNT(*) FROM `cb_event_message`) as row2 LIMIT 1', $count);
+
+    }
+
+}

--- a/tests/Pixie/QueryBuilderTest.php
+++ b/tests/Pixie/QueryBuilderTest.php
@@ -86,12 +86,5 @@ class QueryBuilder extends TestCase
 
         $this->assertEquals(null, $id);
     }
-
-    /**
-     * @expectedException \Pixie\Exception
-     * @expectedExceptionCode 3
-     */
-    public function testTableNotSpecifiedException(){
-        $this->builder->where('a', 'b')->get();
-    }
+    
 }


### PR DESCRIPTION
Added support for not defining any table (so calling `QueryBuilderHandler()->table()` is no longer required).

Can be useful for situations where you are using multiple subqueries to generate the rows without doing a specific query to any tables.

**SQL Example:**

``` sql
SELECT (SELECT COUNT(*) FROM `mail`) as mail_count, (SELECT COUNT(*) FROM `event_message`) as message_count
```

**Pixie example:**

``` php
$subQuery1 = $this->builder->table('mail')->select($this->builder->raw('COUNT(*)'));
$subQuery2 = $this->builder->table('event_message')->select($this->builder->raw('COUNT(*)'));

$count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'), $this->builder->subQuery($subQuery2, 'row2'))->first();
```

I've created tests for this, which can be found in the `NoTableSubQueryTest` test-class.
