### PR TITLE
Bugfix where false bool

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -606,6 +606,11 @@ class QueryBuilderHandler
             $value = $operator;
             $operator = '=';
         }
+
+        if(is_bool($value)) {
+            $value = (int)$value;
+        }
+        
         return $this->whereHandler($key, $operator, $value);
     }
 

--- a/tests/Pixie/QueryBuilderTest.php
+++ b/tests/Pixie/QueryBuilderTest.php
@@ -94,4 +94,9 @@ class QueryBuilder extends TestCase
     public function testTableNotSpecifiedException(){
         $this->builder->where('a', 'b')->get();
     }
+
+    public function testFalseBoolWhere() {
+        $result = $this->builder->table('test')->where('id', '=', false);
+        $this->assertEquals('SELECT * FROM `cb_test` WHERE `id` = 0', $result->getQuery()->getRawSql());
+    }
 }

--- a/tests/Pixie/QueryBuilderTest.php
+++ b/tests/Pixie/QueryBuilderTest.php
@@ -96,7 +96,7 @@ class QueryBuilder extends TestCase
     }
 
     public function testFalseBoolWhere() {
-        $result = $this->builder->table('test')->where('id', '=', false);
-        $this->assertEquals('SELECT * FROM `cb_test` WHERE `id` = 0', $result->getQuery()->getRawSql());
+        $result = $this->builder->table('test')->where('deleted', '=', false);
+        $this->assertEquals('SELECT * FROM `cb_test` WHERE `deleted` = 0', $result->getQuery()->getRawSql());
     }
 }


### PR DESCRIPTION
Fixed error on PHP 5.6.10 - not sure if other versions are affected.

**Query:**

``` php
$result = $this->builder->table('test')->where('deleted', '=', false);
```

**Causes invalid query:**

``` sql
SELECT * FROM `cb_test` WHERE `deleted` =  // no quotation marks or int-replacement here
```

Tests added: `QueryBuilderTest` -> `testFalseBoolWhere()`
