### PR TITLE
[bugfix] Float values are inserted to a built SQL query incorrectly when some locales are set in PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - curl -sS http://getcomposer.org/installer | php

--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -271,7 +271,7 @@ class QueryBuilderHandler
      * @param string $type
      * @param array  $dataToBePassed
      *
-     * @return mixed
+     * @return QueryObject
      * @throws Exception
      */
     public function getQuery($type = 'select', $dataToBePassed = array())
@@ -291,7 +291,7 @@ class QueryBuilderHandler
 
     /**
      * @param QueryBuilderHandler $queryBuilder
-     * @param null                $alias
+     * @param string|null         $alias
      *
      * @return Raw
      */
@@ -440,8 +440,7 @@ class QueryBuilderHandler
     }
 
     /**
-     * @param $tables Single table or multiple tables as an array or as
-     *                multiple parameters
+     * @param string|string[] $tables Single table or multiple tables as an array or as multiple parameters
      *
      * @return static
      */
@@ -880,7 +879,7 @@ class QueryBuilderHandler
      * @param $value
      * @param $bindings
      *
-     * @return mixed
+     * @return Raw
      */
     public function raw($value, $bindings = array())
     {

--- a/src/Pixie/QueryBuilder/QueryObject.php
+++ b/src/Pixie/QueryBuilder/QueryObject.php
@@ -87,6 +87,10 @@ class QueryObject
             if (is_null($value)) {
                 $values[$key] = 'NULL';
             }
+
+            if (is_float($value)) {
+                $values[$key] = str_replace(',', '.', $value);
+            }
         }
 
         $query = preg_replace($keys, $values, $query, 1, $count);

--- a/tests/Pixie/QueryObjectTest.php
+++ b/tests/Pixie/QueryObjectTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pixie;
+
+use Pixie\QueryBuilder\QueryBuilderHandler;
+
+class QueryObjectTest extends TestCase
+{
+    /**
+     * Tests how a float value is inserted to the raw query
+     */
+    public function testFloatValuesToRawSql()
+    {
+        $originalLocale = setlocale(LC_NUMERIC, null);
+        $builder = new QueryBuilderHandler($this->mockConnection);
+
+        // A locale with dot decimal separator
+        setlocale(LC_NUMERIC, 'en_US');
+        $query = $builder->table('table_name')->select('*')->where('field_name', 12.3456789);
+        $this->assertEquals(
+            'SELECT * FROM `cb_table_name` WHERE `field_name` = 12.3456789',
+            $query->getQuery()->getRawSql()
+        );
+
+        // A locale with comma decimal separator
+        setlocale(LC_NUMERIC, 'ru_RU');
+        $query = $builder->table('table_name')->select('*')->where('field_name', 98.7654321);
+        $this->assertEquals(
+            'SELECT * FROM `cb_table_name` WHERE `field_name` = 98.7654321',
+            $query->getQuery()->getRawSql()
+        );
+
+        setlocale(LC_NUMERIC, $originalLocale);
+    }
+}


### PR DESCRIPTION
The bug is described here: https://github.com/usmanhalalit/pixie/issues/166

The reason is that PHP uses different symbols as decimal point depending on locale but SQL accepts only dot as a decimal point.