### PR TITLE
Query event

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -154,7 +154,7 @@ class QueryBuilderHandler
         }
         $pdoStatement->execute();
         $executionTime = microtime(true) - $start;
-        $this->fireEvents('query', $sql, $bindings);
+        $this->fireEvents('query', $sql, $bindings, $executionTime);
         return array($pdoStatement, $executionTime);
     }
 

--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -153,7 +153,9 @@ class QueryBuilderHandler
             );
         }
         $pdoStatement->execute();
-        return array($pdoStatement, microtime(true) - $start);
+        $executionTime = microtime(true) - $start;
+        $this->fireEvents('query', $sql, $bindings);
+        return array($pdoStatement, $executionTime);
     }
 
     /**


### PR DESCRIPTION
Added an event **query** that fire after any statement execution.
This is useful if we want to log all the queries.

Use example:
`
$instance = new Connection('mysql', $config);
$instance = $instance->getQueryBuilder();
$instance->registerEvent('query', '', function($builder, $sql, $binding, $executionTime) {
    $sql = str_replace('?', "'%s'", $sql);
    $rawSql = vsprintf($sql, $binding);
    Logger::info([
        'sql' => $rawSql,
        'executionTime' => $executionTime
    ]);
});
`