### PR TITLE
support parameterized raw expressions in inserts/updates/criteria values

### DIFF
--- a/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -141,6 +141,7 @@ abstract class BaseAdapter
             $keys[] = $key;
             if ($value instanceof Raw) {
                 $values[] = (string) $value;
+                $bindings = array_merge($bindings, $value->getBindings());
             } else {
                 $values[] =  '?';
                 $bindings[] = $value;
@@ -226,6 +227,7 @@ abstract class BaseAdapter
         foreach ($data as $key => $value) {
             if ($value instanceof Raw) {
                 $statement .= $this->wrapSanitizer($key) . '=' . $value . ',';
+                $bindings = array_merge($bindings, $value->getBindings());
             } else {
                 $statement .= $this->wrapSanitizer($key) . '=?,';
                 $bindings[] = $value;
@@ -408,6 +410,9 @@ abstract class BaseAdapter
                 }
             } elseif ($value instanceof Raw) {
                 $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value ";
+                if ($bindValues) {
+                    $bindings = array_merge($bindings, $value->getBindings());
+                }
             } else {
                 // Usual where like criteria
 

--- a/tests/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pixie/QueryBuilderBehaviorTest.php
@@ -73,10 +73,11 @@ class QueryBuilderTest extends TestCase
             ->where('simple', 'criteria')
             ->where($this->builder->raw('RAW'))
             ->where($this->builder->raw('PARAMETERIZED_ONE(?)', 'foo'))
-            ->where($this->builder->raw('PARAMETERIZED_SEVERAL(?, ?, ?)', array(1, '2', 'foo')));
+            ->where($this->builder->raw('PARAMETERIZED_SEVERAL(?, ?, ?)', array(1, '2', 'foo')))
+            ->where('raw_parameterized_value', '=', $this->builder->raw('FUNC(?)', 'parm'));
 
         $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `simple` = 'criteria' AND RAW AND PARAMETERIZED_ONE('foo') AND PARAMETERIZED_SEVERAL(1, '2', 'foo')",
+            "SELECT * FROM `cb_my_table` WHERE `simple` = 'criteria' AND RAW AND PARAMETERIZED_ONE('foo') AND PARAMETERIZED_SEVERAL(1, '2', 'foo') AND `raw_parameterized_value` = FUNC('parm')",
             $query->getQuery()->getRawSql()
         );
     }
@@ -191,6 +192,16 @@ class QueryBuilderTest extends TestCase
             , $builder->getQuery('insert', $data)->getRawSql());
     }
 
+    public function testInsertQueryWithRawParams()
+    {
+        $builder = $this->builder->from('my_table');
+        $data = array('key' => 'Name',
+                'value' => $this->builder->raw('UPPER(?)', 'Sana'),);
+
+        $this->assertEquals("INSERT INTO `cb_my_table` (`key`,`value`) VALUES ('Name',UPPER('Sana'))"
+            , $builder->getQuery('insert', $data)->getRawSql());
+    }
+
     public function testInsertIgnoreQuery()
     {
         $builder = $this->builder->from('my_table');
@@ -201,6 +212,16 @@ class QueryBuilderTest extends TestCase
             , $builder->getQuery('insertignore', $data)->getRawSql());
     }
 
+    public function testInsertIgnoreQueryWithRawParams()
+    {
+        $builder = $this->builder->from('my_table');
+        $data = array('key' => 'Name',
+                'value' => $this->builder->raw('UPPER(?)', 'Sana'),);
+
+        $this->assertEquals("INSERT IGNORE INTO `cb_my_table` (`key`,`value`) VALUES ('Name',UPPER('Sana'))"
+            , $builder->getQuery('insertignore', $data)->getRawSql());
+    }
+
     public function testReplaceQuery()
     {
         $builder = $this->builder->from('my_table');
@@ -208,6 +229,16 @@ class QueryBuilderTest extends TestCase
             'value' => 'Sana',);
 
         $this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
+            , $builder->getQuery('replace', $data)->getRawSql());
+    }
+
+    public function testReplaceQueryWithRawParams()
+    {
+        $builder = $this->builder->from('my_table');
+        $data = array('key' => 'Name',
+                'value' => $this->builder->raw('UPPER(?)', 'Sana'),);
+
+        $this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name',UPPER('Sana'))"
             , $builder->getQuery('replace', $data)->getRawSql());
     }
 
@@ -237,6 +268,19 @@ class QueryBuilderTest extends TestCase
         );
 
         $this->assertEquals("UPDATE `cb_my_table` SET `key`='Sana',`value`='Amrin' WHERE `value` = 'Sana'"
+            , $builder->getQuery('update', $data)->getRawSql());
+    }
+
+    public function testUpdateQueryWithRawParams()
+    {
+        $builder = $this->builder->table('my_table')->where('value', 'Sana');
+
+        $data = array(
+            'key' => 'Sana',
+            'value' => $this->builder->raw('UPPER(?)', 'Amrin'),
+        );
+
+        $this->assertEquals("UPDATE `cb_my_table` SET `key`='Sana',`value`=UPPER('Amrin') WHERE `value` = 'Sana'"
             , $builder->getQuery('update', $data)->getRawSql());
     }
 


### PR DESCRIPTION
This PR enables using `raw()` *expressions* with parameters in insert queries, update queries and inside (right-hand side) value expressions of (where) criteria. Tests updated accordingly.

### Insert

```php
QB::table('people')->getQuery('insert', [
    'firstname' => 'Jane',
    'lastname'  => QB::raw('UPPER(?)', 'Doe'),
    'age'       => 27
])->getRawSql();

// before: INSERT INTO `people` (`firstname`,`lastname`,`age`) VALUES ('Jane',UPPER(27),?)
// after:  INSERT INTO `people` (`firstname`,`lastname`,`age`) VALUES ('Jane',UPPER('Doe'),27)
```

### Where

```php
QB::table('people')
    ->where('firstname', '=', 'Jane')
    ->where('lastname', '=', QB::raw('UPPER(?)', 'Doe'))
    ->getQuery()->getRawSql();

// before: SELECT * FROM `people` WHERE `firstname` = 'Jane' AND `lastname` = UPPER(?)
// after:  SELECT * FROM `people` WHERE `firstname` = 'Jane' AND `lastname` = UPPER('Doe')
```