### PR TITLE
Add prefix for an alias of the main table

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -973,6 +973,9 @@ class QueryBuilderHandler
             $target = &$value;
             if (!is_int($key)) {
                 $target = &$key;
+                if (!$tableFieldMix) {
+                    $value = $this->tablePrefix . $value;
+                }
             }
 
             if (!$tableFieldMix || ($tableFieldMix && strpos($target, '.') !== false)) {

--- a/tests/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pixie/QueryBuilderBehaviorTest.php
@@ -67,6 +67,17 @@ class QueryBuilderTest extends TestCase
         );
     }
 
+    public function testSelectWithPrefixAndJoin()
+    {
+        $query = $this->builder->from(['my_table' => 'c0'])->select('c0.entity_id')
+            ->leftJoin(['second_table', 'c1'], 'c1.entity_id', '=', 'c0.entity_id');
+
+        $this->assertEquals(
+            "SELECT `cb_c0`.`entity_id` FROM `cb_my_table` AS `cb_c0` LEFT JOIN `cb_second_table` AS `cb_c1` ON `cb_c1`.`entity_id` = `cb_c0`.`entity_id`",
+            $query->getQuery()->getRawSql()
+        );
+    }
+
     public function testRawStatementsWithinCriteria()
     {
         $query = $this->builder->from('my_table')


### PR DESCRIPTION
I noticed that prefix is not added for an alias of the main table but added for columns with alias in joins.

For example:
prefix set to: `cb_`
```
$qb->from(['my_table' => 'c0'])->select('c0.entity_id')->leftJoin(['second_table', 'c1'], 'c1.entity_id', '=', 'c0.entity_id');
```
Will be generated this sql:
```
SELECT `cb_c0`.`entity_id` FROM `cb_my_table` AS `c0` LEFT JOIN `cb_second_table` AS `cb_c1` ON `cb_c1`.`entity_id` = `cb_c0`.`entity_id`
```

As can you see, the prefix was not added for an alias of the main table.