### PR TITLE
fixed QueryBuilderHandler dynamic properties for PHP 8.2

### DIFF
--- a/src/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -38,6 +38,16 @@ class QueryBuilderHandler
     protected $tablePrefix = null;
 
     /**
+     * @var string
+     */
+    protected $adapter;
+
+    /**
+     * @var array
+     */
+    protected $adapterConfig;
+    
+    /**
      * @var \Pixie\QueryBuilder\Adapters\BaseAdapter
      */
     protected $adapterInstance;


### PR DESCRIPTION
Fixed deprecation issued by PHP 8.2 for dynamically created properties (adapter and adapterConfig) in QueryBuilderHandler constructor